### PR TITLE
Added submitSurveyAnswersV2 endpoint

### DIFF
--- a/src/main/kotlin/fi/metatavu/oss/api/impl/devicesurveys/devicesurveydata/DeviceSurveyDataApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/oss/api/impl/devicesurveys/devicesurveydata/DeviceSurveyDataApiImpl.kt
@@ -6,6 +6,7 @@ import fi.metatavu.oss.api.impl.devicesurveys.DeviceSurveyController
 import fi.metatavu.oss.api.impl.pages.PagesController
 import fi.metatavu.oss.api.impl.pages.answers.PageAnswerController
 import fi.metatavu.oss.api.impl.pages.questions.PageQuestionController
+import fi.metatavu.oss.api.impl.surveys.SurveyController
 import fi.metatavu.oss.api.model.DevicePageSurveyAnswer
 import io.quarkus.hibernate.reactive.panache.common.runtime.ReactiveTransactional
 import io.smallrye.mutiny.Uni
@@ -49,6 +50,9 @@ class DeviceSurveyDataApiImpl: fi.metatavu.oss.api.spec.DeviceDataApi, AbstractA
 
     @Inject
     lateinit var pagesController: PagesController
+
+    @Inject
+    lateinit var surveyController: SurveyController
 
     @Inject
     lateinit var vertx: Vertx
@@ -123,7 +127,53 @@ class DeviceSurveyDataApiImpl: fi.metatavu.oss.api.spec.DeviceDataApi, AbstractA
 
         try {
             pageAnswerController.create(
-                deviceSurvey = deviceSurvey,
+                device = deviceSurvey.device,
+                page = page,
+                pageQuestion = question,
+                answer = devicePageSurveyAnswer
+            )
+        } catch (e: Exception) {
+            logger.error("Failed to create page answer", e)
+            return@async createBadRequest("Invalid answer")
+        }
+
+        return@async createAccepted(null)
+    }.asUni()
+
+    @ReactiveTransactional
+    override fun submitSurveyAnswerV2(
+        deviceId: UUID,
+        devicePageSurveyAnswer: DevicePageSurveyAnswer
+    ): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
+        if (!isAuthorizedDevice(deviceId)) return@async createUnauthorized(UNAUTHORIZED)
+        if (devicePageSurveyAnswer.answer.isNullOrEmpty()) {
+            return@async createBadRequest("Answer is required")
+        }
+
+        val device = deviceController.findDevice(deviceId) ?: return@async createNotFoundWithMessage(
+            target = DEVICE,
+            id = deviceId
+        )
+
+        val pageId = devicePageSurveyAnswer.pageId ?: return@async createBadRequest("Page ID is required")
+
+        val page = pagesController.findPage(pageId) ?: return@async createNotFoundWithMessage(
+            target = PAGE,
+            id = pageId
+        )
+
+        surveyController.findSurvey(page.survey.id) ?: return@async createNotFoundWithMessage(
+            target = SURVEY,
+            id = page.survey.id
+        )
+
+        val question = pageQuestionController.find(page) ?: return@async createNotFound(
+            "No question found for page $pageId"
+        )
+
+        try {
+            pageAnswerController.create(
+                device = device,
                 page = page,
                 pageQuestion = question,
                 answer = devicePageSurveyAnswer

--- a/src/main/kotlin/fi/metatavu/oss/api/impl/pages/answers/PageAnswerController.kt
+++ b/src/main/kotlin/fi/metatavu/oss/api/impl/pages/answers/PageAnswerController.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import fi.metatavu.oss.api.impl.devices.DeviceEntity
-import fi.metatavu.oss.api.impl.devicesurveys.DeviceSurveyEntity
 import fi.metatavu.oss.api.impl.pages.PageEntity
 import fi.metatavu.oss.api.impl.pages.answers.entities.PageAnswerBaseEntity
 import fi.metatavu.oss.api.impl.pages.answers.entities.PageAnswerMulti
@@ -77,7 +76,7 @@ class PageAnswerController {
     /**
      * Creates a new page answer for the page
      *
-     * @param deviceSurvey device survey
+     * @param device device
      * @param page page
      * @param pageQuestion question that was answered
      * @param answer answer as a string
@@ -86,13 +85,13 @@ class PageAnswerController {
      * @throws JsonMappingException
      */
     suspend fun create(
-        deviceSurvey: DeviceSurveyEntity,
+        device: DeviceEntity,
         page: PageEntity,
         pageQuestion: PageQuestionEntity,
         answer: DevicePageSurveyAnswer
     ): PageAnswerBaseEntity {
         val answerKey = createAnswerKey(
-            device = deviceSurvey.device,
+            device = device,
             page = page,
             answer = answer
         )
@@ -111,7 +110,7 @@ class PageAnswerController {
                     ?: throw IllegalArgumentException("Invalid option id $answerStringOriginal")
                 createSingleSelectAnswer(
                     answerKey = answerKey,
-                    deviceSurvey = deviceSurvey,
+                    device = device,
                     page = page,
                     option = option
                 )
@@ -124,7 +123,7 @@ class PageAnswerController {
                 }
                 createMultiSelectAnswer(
                     answerKey = answerKey,
-                    deviceSurvey = deviceSurvey,
+                    device = device,
                     page = page,
                     options = options
                 )
@@ -132,7 +131,7 @@ class PageAnswerController {
 
             FREETEXT -> createFreetextAnswer(
                 answerKey = answerKey,
-                deviceSurvey= deviceSurvey,
+                device= device,
                 page = page,
                 answerStringOriginal = answerStringOriginal
             )
@@ -177,14 +176,14 @@ class PageAnswerController {
      * Creates answer for a freetext question
      *
      * @param answerKey unique key for the answer
-     * @param deviceSurvey device survey where the answer was published
+     * @param device device where the answer was published
      * @param page page where the answer was published
      * @param answerStringOriginal answer as a string
      * @return created answer
      */
     private suspend fun createFreetextAnswer(
         answerKey: String?,
-        deviceSurvey: DeviceSurveyEntity,
+        device: DeviceEntity,
         page: PageEntity,
         answerStringOriginal: String
     ): PageAnswerText {
@@ -192,7 +191,7 @@ class PageAnswerController {
             id = UUID.randomUUID(),
             answerKey = answerKey,
             page = page,
-            deviceEntity = deviceSurvey.device,
+            deviceEntity = device,
             text = answerStringOriginal
         )
     }
@@ -201,14 +200,14 @@ class PageAnswerController {
      * Creates answer to multi select question
      *
      * @param answerKey unique key for the answer
-     * @param deviceSurvey device survey where the answer was published
+     * @param device device where the answer was published
      * @param page page where the answer was published
      * @param options which options were selected
      * @return created answer
      */
     private suspend fun createMultiSelectAnswer(
         answerKey: String?,
-        deviceSurvey: DeviceSurveyEntity,
+        device: DeviceEntity,
         page: PageEntity,
         options: List<QuestionOptionEntity>
     ): PageAnswerMulti {
@@ -216,7 +215,7 @@ class PageAnswerController {
             id = UUID.randomUUID(),
             answerKey = answerKey,
             page = page,
-            deviceEntity = deviceSurvey.device
+            deviceEntity = device
         )
         options.forEach { answerOption ->
             pageAnswerMultiToOptionsRepository.create(
@@ -233,14 +232,14 @@ class PageAnswerController {
      * Creates a single select answer
      *
      * @param answerKey unique key for the answer
-     * @param deviceSurvey where it was published
+     * @param device where it was published
      * @param page which page it was answered on
      * @param option which option was selected
      * @return created answer
      */
     private suspend fun createSingleSelectAnswer(
         answerKey: String?,
-        deviceSurvey: DeviceSurveyEntity,
+        device: DeviceEntity,
         page: PageEntity,
         option: QuestionOptionEntity
     ): PageAnswerSingle {
@@ -249,7 +248,7 @@ class PageAnswerController {
             answerKey = answerKey,
             page = page,
             option = option,
-            deviceEntity = deviceSurvey.device
+            deviceEntity = device
         )
     }
 

--- a/src/test/kotlin/fi/metatavu/oss/api/test/functional/impl/DeviceSurveyDatasTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/oss/api/test/functional/impl/DeviceSurveyDatasTestBuilderResource.kt
@@ -77,6 +77,39 @@ class DeviceSurveyDatasTestBuilderResource(
     }
 
     /**
+     * Submits the answer from the survey using the V2 API
+     *
+     * @param deviceId device id
+     * @param devicePageSurveyAnswer device page survey answer
+     * @param surveyId survey id (not needed for actual request)
+     * @param pageId page id (not needed for actual request)
+     */
+    fun submitSurveyAnswer(
+        deviceId: UUID,
+        devicePageSurveyAnswer: DevicePageSurveyAnswer,
+        surveyId: UUID,
+        pageId: UUID
+    ) {
+        api.submitSurveyAnswerV2(
+            deviceId = deviceId,
+            devicePageSurveyAnswer = devicePageSurveyAnswer
+        )
+
+        // add it as closable to resource which can delete the answer
+        surveyAnswersResource.list(
+            surveyId = surveyId,
+            pageId = pageId
+        ).forEach {
+            if (submittedClosableAnswersIDs.contains(it.id)) {
+                return@forEach
+            }
+            surveyAnswersResource.addClosable(it)
+            surveyAnswersResource.answerToSurvey[it.id!!] = surveyId
+            submittedClosableAnswersIDs.add(it.id)
+        }
+    }
+
+    /**
      * Submits the answer from the survey
      *
      * @param deviceId device id

--- a/src/test/kotlin/fi/metatavu/oss/api/test/functional/tests/AbstractResourceTest.kt
+++ b/src/test/kotlin/fi/metatavu/oss/api/test/functional/tests/AbstractResourceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
+import java.util.*
 
 /**
  * Abstract base class for resource tests
@@ -89,6 +90,36 @@ abstract class AbstractResourceTest {
                 deviceAnswerId = deviceAnswerId
             ),
             surveyId = deviceSurvey.surveyId
+        )
+    }
+
+    /**
+     * Creates an answer for a page using V2 API
+     *
+     * @param testBuilder test builder
+     * @param deviceId device id
+     * @param page page
+     * @param answer answer
+     * @param deviceAnswerId device answer id (optional
+     * @param surveyId survey id
+     */
+    protected fun createPageAnswer(
+        testBuilder: TestBuilder,
+        deviceId: UUID,
+        page: Page,
+        answer: String,
+        deviceAnswerId: Long? = null,
+        surveyId: UUID
+    ) {
+        testBuilder.manager.deviceData.submitSurveyAnswer(
+            deviceId = deviceId,
+            devicePageSurveyAnswer = DevicePageSurveyAnswer(
+                pageId = page.id,
+                answer = answer,
+                deviceAnswerId = deviceAnswerId
+            ),
+            surveyId = surveyId,
+            pageId = page.id!!
         )
     }
 

--- a/src/test/kotlin/fi/metatavu/oss/api/test/functional/tests/DeviceSurveyDataTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/oss/api/test/functional/tests/DeviceSurveyDataTestIT.kt
@@ -564,7 +564,7 @@ class DeviceSurveyDataTestIT : AbstractResourceTest() {
             )
 
             for (page in pages) {
-                // Submit answer 1 three times (without deviceAnswerId simulating direct submission)
+                // Submit answer 1 three times (without deviceAnswerId simulating direct submission using v1 API)
 
                 for (i in 1..3) {
                     createPageAnswer(
@@ -576,23 +576,25 @@ class DeviceSurveyDataTestIT : AbstractResourceTest() {
                     )
                 }
 
-                // Submit answer 2 three times (with deviceAnswerId simulating postponed submission from device)
+                // Submit answer 2 three times (with deviceAnswerId simulating postponed submission from device using v2 API)
                 for (i in 1..3) {
                     createPageAnswer(
                         testBuilder = testBuilder,
-                        deviceSurvey = deviceSurvey,
+                        deviceId = deviceId,
+                        surveyId = createdSurvey.id,
                         page = page,
                         answer = "Sumurai",
                         deviceAnswerId = 5
                     )
                 }
 
-                // Submit answer 3 three times (with deviceAnswerId simulating postponed submission from device)
+                // Submit answer 3 three times (with deviceAnswerId simulating postponed submission from device using v2 API)
                 for (i in 1..3) {
                     createPageAnswer(
                         testBuilder = testBuilder,
-                        deviceSurvey = deviceSurvey,
+                        deviceId = deviceId,
                         page = page,
+                        surveyId = createdSurvey.id,
                         answer = "Pyöveli",
                         deviceAnswerId = 6
                     )
@@ -668,7 +670,7 @@ class DeviceSurveyDataTestIT : AbstractResourceTest() {
             )
 
             for (page in pages) {
-                // Submit answer 1 three times (without deviceAnswerId simulating direct submission)
+                // Submit answer 1 three times (without deviceAnswerId simulating direct submission using v1 API)
 
                 for (i in 1..3) {
                     createPageAnswer(
@@ -680,24 +682,26 @@ class DeviceSurveyDataTestIT : AbstractResourceTest() {
                     )
                 }
 
-                // Submit answer 2 three times (with deviceAnswerId simulating postponed submission from device)
+                // Submit answer 2 three times (with deviceAnswerId simulating postponed submission from device using v2 API)
                 for (i in 1..3) {
                     createPageAnswer(
                         testBuilder = testBuilder,
-                        deviceSurvey = deviceSurvey,
+                        deviceId = deviceId,
                         page = page,
                         answer = getOptionValueByOrderNumber(page = page, orderNumber = 1),
+                        surveyId = createdSurvey.id,
                         deviceAnswerId = 5
                     )
                 }
 
-                // Submit answer 3 three times (with deviceAnswerId simulating postponed submission from device)
+                // Submit answer 3 three times (with deviceAnswerId simulating postponed submission from device using v2 API)
                 for (i in 1..3) {
                     createPageAnswer(
                         testBuilder = testBuilder,
-                        deviceSurvey = deviceSurvey,
+                        deviceId = deviceId,
                         page = page,
                         answer = getOptionValueByOrderNumber(page = page, orderNumber = 2),
+                        surveyId = createdSurvey.id,
                         deviceAnswerId = 6
                     )
                 }
@@ -772,7 +776,7 @@ class DeviceSurveyDataTestIT : AbstractResourceTest() {
             )
 
             for (page in pages) {
-                // Submit answer 1 three times (without deviceAnswerId simulating direct submission)
+                // Submit answer 1 three times (without deviceAnswerId simulating direct submission using v1 API)
 
                 for (i in 1..3) {
                     createPageAnswer(
@@ -787,12 +791,13 @@ class DeviceSurveyDataTestIT : AbstractResourceTest() {
                     )
                 }
 
-                // Submit answer 2 three times (with deviceAnswerId simulating postponed submission from device)
+                // Submit answer 2 three times (with deviceAnswerId simulating postponed submission from device using v2 API)
                 for (i in 1..3) {
                     createPageAnswer(
                         testBuilder = testBuilder,
-                        deviceSurvey = deviceSurvey,
+                        deviceId = deviceId,
                         page = page,
+                        surveyId = createdSurvey.id,
                         answer = jacksonObjectMapper().writeValueAsString(listOf(
                             getOptionValueByOrderNumber(page = page, orderNumber = 1)
                         )),
@@ -800,11 +805,12 @@ class DeviceSurveyDataTestIT : AbstractResourceTest() {
                     )
                 }
 
-                // Submit answer 3 three times (with deviceAnswerId simulating postponed submission from device)
+                // Submit answer 3 three times (with deviceAnswerId simulating postponed submission from device using v2 API)
                 for (i in 1..3) {
                     createPageAnswer(
                         testBuilder = testBuilder,
-                        deviceSurvey = deviceSurvey,
+                        deviceId = deviceId,
+                        surveyId = createdSurvey.id,
                         page = page,
                         answer = jacksonObjectMapper().writeValueAsString(listOf(
                             getOptionValueByOrderNumber(page = page, orderNumber = 0),


### PR DESCRIPTION
Added submitSurveyAnswersV2 endpoint for submitting device survey answers without relation to device survey

- Changed existing tests for duplicate answer guards to use the new API as they'd be the ones in used in production

Resolves #83 